### PR TITLE
Clean up constants in Robot.java by moving them to a new file.

### DIFF
--- a/src/org/oastem/frc/strong/N.java
+++ b/src/org/oastem/frc/strong/N.java
@@ -1,0 +1,15 @@
+package org.oastem.frc.strong;
+
+class N {
+	class Drive {
+		// Ports
+		public final int FRONT_LEFT = 0;
+		public final int FRONT_RIGHT = 2;
+		public final int BACK_LEFT = 1;
+		public final int BACK_RIGHT = 3;
+
+		// Values
+		public final int ENC_CODE_PER_REV = 2048;
+		public final int WHEEL_DIAM = 8;
+	}
+}

--- a/src/org/oastem/frc/strong/N.java
+++ b/src/org/oastem/frc/strong/N.java
@@ -1,5 +1,10 @@
 package org.oastem.frc.strong;
 
+/**
+ * Constants for use with Robot.java.
+ * 
+ * @author KTOmega
+ */
 class N {
 	class Drive {
 		// Ports

--- a/src/org/oastem/frc/strong/N.java
+++ b/src/org/oastem/frc/strong/N.java
@@ -3,13 +3,13 @@ package org.oastem.frc.strong;
 class N {
 	class Drive {
 		// Ports
-		public final int FRONT_LEFT = 0;
-		public final int FRONT_RIGHT = 2;
-		public final int BACK_LEFT = 1;
-		public final int BACK_RIGHT = 3;
+		public static final int FRONT_LEFT = 0;
+		public static final int FRONT_RIGHT = 2;
+		public static final int BACK_LEFT = 1;
+		public static final int BACK_RIGHT = 3;
 
 		// Values
-		public final int ENC_CODE_PER_REV = 2048;
-		public final int WHEEL_DIAM = 8;
+		public static final int ENC_CODE_PER_REV = 2048;
+		public static final int WHEEL_DIAM = 8;
 	}
 }

--- a/src/org/oastem/frc/strong/Robot.java
+++ b/src/org/oastem/frc/strong/Robot.java
@@ -32,17 +32,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
  * instead if you're new.
  */
 public class Robot extends SampleRobot {
-	// Ports
-	private final int FRONT_LEFT_CAN_DRIVE = 0;
-	private final int FRONT_RIGHT_CAN_DRIVE = 2;
-	private final int BACK_LEFT_CAN_DRIVE = 1;
-	private final int BACK_RIGHT_CAN_DRIVE = 3;
-
-
-	// Values
-	private final int DRIVE_ENC_CODE_PER_REV = 2048;
-	private final int DRIVE_WHEEL_DIAM = 8;
-
 	// Objects
 	private TalonDriveSystem talonDrive = TalonDriveSystem.getInstance();
 	private LogitechGamingPad pad;
@@ -59,8 +48,9 @@ public class Robot extends SampleRobot {
 	private boolean eStop2Pressed;
 
 	public Robot() {
-		talonDrive.initializeTalonDrive(FRONT_LEFT_CAN_DRIVE, BACK_LEFT_CAN_DRIVE, FRONT_RIGHT_CAN_DRIVE,
-				BACK_RIGHT_CAN_DRIVE, DRIVE_ENC_CODE_PER_REV, DRIVE_WHEEL_DIAM);
+		talonDrive.initializeTalonDrive(N.Drive.FRONT_LEFT, N.Drive.BACK_LEFT,
+			N.Drive.FRONT_RIGHT, N.Drive.BACK_RIGHT,
+			N.Drive.ENC_CODE_PER_REV, N.Drive.WHEEL_DIAM);
 	}
 
 	public void robotInit() {


### PR DESCRIPTION
Introduced at the January 14 Saturday FRC meeting, showed the code to @mduong15 on the mecanum test code.

`Robot.java` always tends to be cluttered with random unorganized constants - to encourage cleaner and more compact code, I think it's better if we move all of these to a class dedicated to constants, called `N.java` - this allows us to address each constant in `Robot.java` through the `N` static namespace, a la Android's `R`.